### PR TITLE
This patch fixes RT bug #60528

### DIFF
--- a/t/all_modules_absolute.t
+++ b/t/all_modules_absolute.t
@@ -1,0 +1,18 @@
+#!perl -T
+
+use strict;
+
+use Test::More tests => 2;
+
+BEGIN {
+    use_ok( "Test::Pod::Coverage" );
+}
+
+my @files = Test::Pod::Coverage::all_modules( File::Spec->rel2abs("blib") );
+
+# The expected files have slashes, not File::Spec separators, because
+# that's how File::Find does it.
+my @expected = qw( Test::Pod::Coverage );
+@files = sort @files;
+@expected = sort @expected;
+is_deeply( \@files, \@expected, "Got all the distro files" );

--- a/t/all_modules_absolute.t
+++ b/t/all_modules_absolute.t
@@ -2,6 +2,7 @@
 
 use strict;
 
+use File::Spec;
 use Test::More tests => 2;
 
 BEGIN {


### PR DESCRIPTION
- Modifies Test::Pod::Coverage::all_modules to cope with absolute dirs
- Adds a corresponding test case
- Haven't bumped the version
- Prompted by MANWAR
